### PR TITLE
Add benchmark suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,10 @@
 !/infiles/3005_test-var.txt
 !/infiles/README.md
 
+# Ignore all benchmarks, except for the records storage.
+/benchmarks/*
+!/benchmarks/bests.json
+!/benchmarks/README.md
+
 # Misc.
 .DS_Store

--- a/benchmarks/bests.json
+++ b/benchmarks/bests.json
@@ -1,0 +1,118 @@
+{
+  "pkg": "lorech/advent-of-code-2024/pkg/puzzles",
+  "os": "darwin",
+  "arch": "arm64",
+  "cpu": "Apple M1 Pro",
+  "results": {
+    "BenchmarkDayEightPartOne-8": {
+      "fun": "BenchmarkDayEightPartOne-8",
+      "ops": 8631,
+      "ns": 142187
+    },
+    "BenchmarkDayEightPartTwo-8": {
+      "fun": "BenchmarkDayEightPartTwo-8",
+      "ops": 1753,
+      "ns": 683552
+    },
+    "BenchmarkDayElevenPartOne-8": {
+      "fun": "BenchmarkDayElevenPartOne-8",
+      "ops": 1,
+      "ns": 1042480958
+    },
+    "BenchmarkDayElevenPartTwo-8": {
+      "fun": "BenchmarkDayElevenPartTwo-8",
+      "ops": 49,
+      "ns": 24161879
+    },
+    "BenchmarkDayFivePartOne-8": {
+      "fun": "BenchmarkDayFivePartOne-8",
+      "ops": 1088,
+      "ns": 1098907
+    },
+    "BenchmarkDayFivePartTwo-8": {
+      "fun": "BenchmarkDayFivePartTwo-8",
+      "ops": 618,
+      "ns": 1941656
+    },
+    "BenchmarkDayFourPartOne-8": {
+      "fun": "BenchmarkDayFourPartOne-8",
+      "ops": 938,
+      "ns": 1267884
+    },
+    "BenchmarkDayFourPartTwo-8": {
+      "fun": "BenchmarkDayFourPartTwo-8",
+      "ops": 754,
+      "ns": 1582738
+    },
+    "BenchmarkDayNinePartOne-8": {
+      "fun": "BenchmarkDayNinePartOne-8",
+      "ops": 49,
+      "ns": 23726758
+    },
+    "BenchmarkDayNinePartTwo-8": {
+      "fun": "BenchmarkDayNinePartTwo-8",
+      "ops": 1,
+      "ns": 16645714375
+    },
+    "BenchmarkDayOnePartOne-8": {
+      "fun": "BenchmarkDayOnePartOne-8",
+      "ops": 1146,
+      "ns": 1017527
+    },
+    "BenchmarkDayOnePartTwo-8": {
+      "fun": "BenchmarkDayOnePartTwo-8",
+      "ops": 1147,
+      "ns": 1048630
+    },
+    "BenchmarkDaySevenPartOne-8": {
+      "fun": "BenchmarkDaySevenPartOne-8",
+      "ops": 1039,
+      "ns": 1153904
+    },
+    "BenchmarkDaySevenPartTwo-8": {
+      "fun": "BenchmarkDaySevenPartTwo-8",
+      "ops": 3,
+      "ns": 414753153
+    },
+    "BenchmarkDaySixPartOne-8": {
+      "fun": "BenchmarkDaySixPartOne-8",
+      "ops": 1060,
+      "ns": 1142941
+    },
+    "BenchmarkDaySixPartTwo-8": {
+      "fun": "BenchmarkDaySixPartTwo-8",
+      "ops": 1,
+      "ns": 2834158167
+    },
+    "BenchmarkDayTenPartOne-8": {
+      "fun": "BenchmarkDayTenPartOne-8",
+      "ops": 3704,
+      "ns": 321192
+    },
+    "BenchmarkDayTenPartTwo-8": {
+      "fun": "BenchmarkDayTenPartTwo-8",
+      "ops": 3733,
+      "ns": 317777
+    },
+    "BenchmarkDayThreePartOne-8": {
+      "fun": "BenchmarkDayThreePartOne-8",
+      "ops": 1332,
+      "ns": 893907
+    },
+    "BenchmarkDayThreePartTwo-8": {
+      "fun": "BenchmarkDayThreePartTwo-8",
+      "ops": 1669,
+      "ns": 725578
+    },
+    "BenchmarkDayTwoPartOne-8": {
+      "fun": "BenchmarkDayTwoPartOne-8",
+      "ops": 5611,
+      "ns": 206996
+    },
+    "BenchmarkDayTwoPartTwo-8": {
+      "fun": "BenchmarkDayTwoPartTwo-8",
+      "ops": 4758,
+      "ns": 249159
+    }
+  }
+}

--- a/cmd/benchmarks/main.go
+++ b/cmd/benchmarks/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "lorech/advent-of-code-2024/pkg/benchmarks"
+
+func main() {
+	benchmarks.Process()
+}

--- a/cmd/solve/main.go
+++ b/cmd/solve/main.go
@@ -1,14 +1,23 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"lorech/advent-of-code-2024/pkg/file"
 	"lorech/advent-of-code-2024/pkg/puzzles"
 )
 
 func main() {
-	solved := 10
-	for day := 1; day <= solved; day++ {
+	start, end := 0, 10
+
+	pDay := flag.Int("day", -1, "Solve a specific day; solves all days by default")
+	flag.Parse()
+
+	if *pDay != -1 {
+		start, end = *pDay, *pDay
+	}
+
+	for day := start; day <= end; day++ {
 		data, error := file.ReadInfile(day)
 		if error != nil {
 			panic(error)

--- a/infiles/README.md
+++ b/infiles/README.md
@@ -17,3 +17,5 @@ You can also create test files using the provided examples in each puzzle's desc
 For the actual puzzles, save the your input file in this directory with the filename `{day}.txt`, where `{day}` is the day of the puzzle (e.g. `1.txt` for Day 1).
 
 For the example puzzles, save the example data into a text file in this directory with the filename `{day}_test.txt`, where `{day}` is the day of the puzzle (e.g. `1_test.txt` for the example data for Day 1).
+
+My file reader also supports adding variations of tests for each day, such as the additional examples provided on the daily puzzle or custom ones, but I intend on not adding actual unit tests for them because they become hard to maintain due to not being able to add them to VCS. If you spot one of these lingering, consider it a bug!

--- a/pkg/benchmarks/benchmark.go
+++ b/pkg/benchmarks/benchmark.go
@@ -1,17 +1,59 @@
 package benchmarks
 
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
 // The output of a single benchmark file.
 type Benchmark struct {
-	pkg     string            // The package the benchmarks were for.
-	os      string            // The OS used to run the benchmarks.
-	arch    string            // The architecture used to run the benchmarks.
-	cpu     string            // The CPU used to run the benchmarks.
-	results []BenchmarkResult // The results of this benchmark.
+	Pkg     string                     `json:"pkg"`     // The package the benchmarks were for.
+	Os      string                     `json:"os"`      // The OS used to run the benchmarks.
+	Arch    string                     `json:"arch"`    // The architecture used to run the benchmarks.
+	Cpu     string                     `json:"cpu"`     // The CPU used to run the benchmarks.
+	Results map[string]BenchmarkResult `json:"results"` // The results of this benchmark.
 }
 
 // The output of a single benchmark.
 type BenchmarkResult struct {
-	fun string // The name of the function tested.
-	ops int    // The cycles taken to benchmark the function.
-	ns  int    // The time of a single benchmark cycle, in nanoseconds.
+	Fun string `json:"fun"` // The name of the function tested. This should match the key of the map used to access this.
+	Ops int    `json:"ops"` // The cycles taken to benchmark the function.
+	Ns  int    `json:"ns"`  // The time of a single benchmark cycle, in nanoseconds.
+}
+
+func (a *BenchmarkResult) Equal(b *BenchmarkResult) bool {
+	return a.Fun == b.Fun && a.Ns == b.Ns
+}
+
+// Fetches the personal best benchmarks from the stored file on disk.
+func PersonalBests() (Benchmark, error) {
+	var b Benchmark
+
+	d, err := os.ReadFile("benchmarks/bests.json")
+	if err != nil {
+		fmt.Printf("Warning: Could not read records file. Reason: %v\n", err)
+		return b, err
+	}
+
+	err = json.Unmarshal(d, &b)
+	if err != nil {
+		fmt.Printf("Warning: Could not process records file. Reason: %v\n", err)
+	}
+
+	return b, err
+}
+
+// Stores a benchmark into the personal bests file.
+func savePersonalBests(data Benchmark) {
+	b, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fmt.Errorf("Error: Could not encode records file. Reason :%v\n", err)
+		return
+	}
+
+	err = os.WriteFile("benchmarks/bests.json", b, 0666)
+	if err != nil {
+		fmt.Errorf("Error: Could not write records file. Reason: %v\n", err)
+	}
 }

--- a/pkg/benchmarks/benchmark.go
+++ b/pkg/benchmarks/benchmark.go
@@ -1,5 +1,6 @@
 package benchmarks
 
+// The output of a single benchmark file.
 type Benchmark struct {
 	pkg     string            // The package the benchmarks were for.
 	os      string            // The OS used to run the benchmarks.
@@ -8,6 +9,7 @@ type Benchmark struct {
 	results []BenchmarkResult // The results of this benchmark.
 }
 
+// The output of a single benchmark.
 type BenchmarkResult struct {
 	fun string // The name of the function tested.
 	ops int    // The cycles taken to benchmark the function.

--- a/pkg/benchmarks/benchmark.go
+++ b/pkg/benchmarks/benchmark.go
@@ -1,0 +1,15 @@
+package benchmarks
+
+type Benchmark struct {
+	pkg     string            // The package the benchmarks were for.
+	os      string            // The OS used to run the benchmarks.
+	arch    string            // The architecture used to run the benchmarks.
+	cpu     string            // The CPU used to run the benchmarks.
+	results []BenchmarkResult // The results of this benchmark.
+}
+
+type BenchmarkResult struct {
+	fun string // The name of the function tested.
+	ops int    // The cycles taken to benchmark the function.
+	ns  int    // The time of a single benchmark cycle, in nanoseconds.
+}

--- a/pkg/benchmarks/benchmarks/sample-processed.txt
+++ b/pkg/benchmarks/benchmarks/sample-processed.txt
@@ -1,0 +1,9 @@
+goos: darwin
+goarch: arm64
+pkg: lorech/advent-of-code-2024/pkg/benchmarks
+cpu: Apple M1 Pro
+BenchmarkNumberOne-8        	    3656	    328111 ns/op
+BenchmarkNumberTwo-8        	    3758	    325689 ns/op
+BenchmarkNumberThree-8      	    1148	   1031164 ns/op
+PASS
+ok  	lorech/advent-of-code-2024/pkg/benchmarks	0.209s

--- a/pkg/benchmarks/benchmarks/sample.txt
+++ b/pkg/benchmarks/benchmarks/sample.txt
@@ -1,0 +1,9 @@
+goos: darwin
+goarch: arm64
+pkg: lorech/advent-of-code-2024/pkg/benchmarks
+cpu: Apple M1 Pro
+BenchmarkNumberOne-8        	    3656	    328111 ns/op
+BenchmarkNumberTwo-8        	    3758	    325689 ns/op
+BenchmarkNumberThree-8      	    1148	   1031164 ns/op
+PASS
+ok  	lorech/advent-of-code-2024/pkg/benchmarks	0.209s

--- a/pkg/benchmarks/parser.go
+++ b/pkg/benchmarks/parser.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 )
 
+// Parses any new benchmark files and compares them with the previous bests,
+// adding any new benchmarks or updating new bests as necessary.
 func Process() {
 	files := findUnprocessedFiles()
 	bms := make([]Benchmark, 0)

--- a/pkg/benchmarks/parser.go
+++ b/pkg/benchmarks/parser.go
@@ -1,0 +1,108 @@
+package benchmarks
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func Process() {
+	files := findUnprocessedFiles()
+	bms := make([]Benchmark, 0)
+
+	for _, file := range files {
+		d, error := os.ReadFile(file)
+		if error != nil {
+			fmt.Printf("Warning: Could not read file %v. Reason: %v", file, error)
+			continue
+		}
+
+		bm, err := processFile(string(d))
+		if err != nil {
+			fmt.Printf("Warning: Could not process file %v. Reason: %v", file, error)
+			continue
+		}
+
+		bms = append(bms, bm)
+	}
+
+	// TODO: Compare the new data to the existing data.
+
+	// TODO: Update the benchmark history file.
+
+	// TODO: Update the new benchmarks to avoid processing them again.
+}
+
+// Finds all unprocessed benchmark files within the benchmark directory.
+func findUnprocessedFiles() []string {
+	files := make([]string, 0)
+
+	content, err := os.ReadDir("benchmarks")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range content {
+		if !f.IsDir() {
+			if !strings.Contains(f.Name(), "-processed") {
+				files = append(files, fmt.Sprintf("benchmarks/%s", f.Name()))
+			}
+		}
+	}
+
+	return files
+}
+
+// Processes a benchmark file into a usable struct for further processing.
+func processFile(data string) (Benchmark, error) {
+	bm := Benchmark{}
+
+	// Validate that the benchmark is in regular TXT output.
+	// TODO: There is probably a better way to check this.
+	valid := strings.Contains(data, "goos: ")
+	if !valid {
+		return bm, fmt.Errorf("File is not a valid benchmark TXT file.")
+	}
+
+	rows := strings.Split(data, "\n")
+	bm.results = make([]BenchmarkResult, len(rows)-6)
+
+	for i, row := range rows {
+		if strings.HasPrefix(row, "Benchmark") {
+			r := strings.Fields(row)
+			f := r[0]
+			c, _ := strconv.Atoi(r[1])
+			l, _ := strconv.Atoi(r[2])
+			bm.results[i-4] = BenchmarkResult{f, c, l}
+			continue
+		}
+
+		if strings.HasPrefix(row, "goos:") {
+			s := strings.Index(row, " ")
+			bm.os = row[s+1:]
+			continue
+		}
+
+		if strings.HasPrefix(row, "goarch:") {
+			s := strings.Index(row, " ")
+			bm.arch = row[s+1:]
+			continue
+		}
+
+		if strings.HasPrefix(row, "pkg:") {
+			s := strings.Index(row, " ")
+			bm.pkg = row[s+1:]
+			continue
+		}
+
+		if strings.HasPrefix(row, "cpu:") {
+			s := strings.Index(row, " ")
+			bm.cpu = row[s+1:]
+			continue
+		}
+	}
+
+	return bm, nil
+}

--- a/pkg/benchmarks/parser.go
+++ b/pkg/benchmarks/parser.go
@@ -3,7 +3,9 @@ package benchmarks
 import (
 	"fmt"
 	"log"
+	"lorech/advent-of-code-2024/pkg/cmaps"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -12,49 +14,85 @@ import (
 // adding any new benchmarks or updating new bests as necessary.
 func Process() {
 	files := findUnprocessedFiles()
+	pFiles := make([]string, 0)
 	bms := make([]Benchmark, 0)
 
 	for _, file := range files {
-		d, error := os.ReadFile(file)
-		if error != nil {
-			fmt.Printf("Warning: Could not read file %v. Reason: %v", file, error)
+		d, err := os.ReadFile(file)
+		if err != nil {
+			fmt.Printf("Warning: Could not read file %v. Reason: %v", file, err)
 			continue
 		}
 
 		bm, err := processFile(string(d))
 		if err != nil {
-			fmt.Printf("Warning: Could not process file %v. Reason: %v", file, error)
+			fmt.Printf("Warning: Could not process file %v. Reason: %v", file, err)
 			continue
 		}
 
 		bms = append(bms, bm)
+		pFiles = append(pFiles, file)
 	}
 
-	// TODO: Compare the new data to the existing data.
-
-	// TODO: Update the benchmark history file.
-
-	// TODO: Update the new benchmarks to avoid processing them again.
+	pb, _ := PersonalBests()
+	pb = updatePersonalBest(pb, bms)
+	savePersonalBests(pb)
+	updateProcessedFiles(pFiles)
 }
 
-// Finds all unprocessed benchmark files within the benchmark directory.
-func findUnprocessedFiles() []string {
-	files := make([]string, 0)
-
-	content, err := os.ReadDir("benchmarks")
-	if err != nil {
-		log.Fatal(err)
+// Merges existing personal bests with a batch of new benchmark data into
+// once complete set of data.
+// WARNING: This currently assumes an existing and identical set of metadata
+// for a benchmark, only updating functions. This is subject to change.
+func updatePersonalBest(pb Benchmark, benchmarks []Benchmark) Benchmark {
+	for _, benchmark := range benchmarks {
+		pb = mergeBenchmarks(pb, benchmark)
 	}
+	return pb
+}
 
-	for _, f := range content {
-		if !f.IsDir() {
-			if !strings.Contains(f.Name(), "-processed") {
-				files = append(files, fmt.Sprintf("benchmarks/%s", f.Name()))
+// Combine two benchmarks, returning a single benchmark with the best results
+// for each function across the two of them.
+// WARNING: This currently assumes an existing and identical set of metadata
+// for a benchmark, only updating functions. This is subject to change.
+func mergeBenchmarks(a Benchmark, b Benchmark) Benchmark {
+	aFuncs := cmaps.KeysSlice(a.Results)
+	bFuncs := cmaps.KeysSlice(b.Results)
+
+	// Update the runtimes of the functions in a.
+	for f, result := range a.Results {
+		if slices.Contains(bFuncs, f) {
+			if result.Ops < b.Results[f].Ops && result.Ns < b.Results[f].Ns {
+				a.Results[f] = b.Results[f]
 			}
 		}
 	}
 
-	return files
+	// Set all the meta data from b to a, as b is expected to be more up-to-date.
+	if a.Pkg == "" {
+		a.Pkg = b.Pkg
+	}
+	if a.Os == "" {
+		a.Os = b.Os
+	}
+	if a.Arch == "" {
+		a.Arch = b.Arch
+	}
+	if a.Cpu == "" {
+		a.Cpu = b.Cpu
+	}
+
+	// Add any missing functions to a, as b is expected to be more up-to-date.
+	for f, result := range b.Results {
+		if !slices.Contains(aFuncs, f) {
+			if a.Results == nil {
+				a.Results = make(map[string]BenchmarkResult)
+			}
+			a.Results[f] = result
+		}
+	}
+
+	return a
 }
 
 // Processes a benchmark file into a usable struct for further processing.
@@ -69,42 +107,78 @@ func processFile(data string) (Benchmark, error) {
 	}
 
 	rows := strings.Split(data, "\n")
-	bm.results = make([]BenchmarkResult, len(rows)-6)
+	bm.Results = make(map[string]BenchmarkResult, len(rows)-6)
 
-	for i, row := range rows {
+	for _, row := range rows {
 		if strings.HasPrefix(row, "Benchmark") {
 			r := strings.Fields(row)
 			f := r[0]
 			c, _ := strconv.Atoi(r[1])
 			l, _ := strconv.Atoi(r[2])
-			bm.results[i-4] = BenchmarkResult{f, c, l}
+			bm.Results[f] = BenchmarkResult{f, c, l}
 			continue
 		}
 
 		if strings.HasPrefix(row, "goos:") {
 			s := strings.Index(row, " ")
-			bm.os = row[s+1:]
+			bm.Os = row[s+1:]
 			continue
 		}
 
 		if strings.HasPrefix(row, "goarch:") {
 			s := strings.Index(row, " ")
-			bm.arch = row[s+1:]
+			bm.Arch = row[s+1:]
 			continue
 		}
 
 		if strings.HasPrefix(row, "pkg:") {
 			s := strings.Index(row, " ")
-			bm.pkg = row[s+1:]
+			bm.Pkg = row[s+1:]
 			continue
 		}
 
 		if strings.HasPrefix(row, "cpu:") {
 			s := strings.Index(row, " ")
-			bm.cpu = row[s+1:]
+			bm.Cpu = row[s+1:]
 			continue
 		}
 	}
 
 	return bm, nil
+}
+
+// Finds all unprocessed benchmark files within the benchmark directory.
+func findUnprocessedFiles() []string {
+	files := make([]string, 0)
+
+	content, err := os.ReadDir("benchmarks")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range content {
+		if !f.IsDir() {
+			if strings.Contains(f.Name(), "bests.json") {
+				continue
+			}
+
+			if !strings.Contains(f.Name(), "-processed") {
+				files = append(files, fmt.Sprintf("benchmarks/%s", f.Name()))
+			}
+		}
+	}
+
+	return files
+}
+
+// Renames all processed files to avoid processing them again on future runs.
+func updateProcessedFiles(files []string) {
+	for _, file := range files {
+		ext := strings.Index(file, ".")
+		if ext != 1 {
+			os.Rename(file, fmt.Sprintf("%s-processed%s", file[:ext], file[ext:]))
+		} else {
+			os.Rename(file, fmt.Sprintf("%s-processed", file))
+		}
+	}
 }

--- a/pkg/benchmarks/parser_test.go
+++ b/pkg/benchmarks/parser_test.go
@@ -1,0 +1,59 @@
+package benchmarks
+
+import (
+	"os"
+	"testing"
+)
+
+// Checks file lookup from the benchmarks directory, ensuring processed files
+// get skipped.
+func TestFileLookup(t *testing.T) {
+	e := []string{"benchmarks/sample.txt"}
+	r := findUnprocessedFiles()
+
+	if len(r) != len(e) || r[0] != e[0] {
+		t.Errorf("findUnprocessedFiles() = %v, expected %v", r, e)
+	}
+}
+
+// Checks if a benchmark output file can be properly parsed into a struct.
+func TestFileProcessing(t *testing.T) {
+	d, error := os.ReadFile("benchmarks/sample.txt")
+	if error != nil {
+		t.Fatalf("Could not read file: Reason: %v", error)
+	}
+
+	e := Benchmark{
+		"lorech/advent-of-code-2024/pkg/benchmarks",
+		"darwin",
+		"arm64",
+		"Apple M1 Pro",
+		[]BenchmarkResult{
+			{
+				"BenchmarkNumberOne-8",
+				3656,
+				328111,
+			},
+			{
+				"BenchmarkNumberTwo-8",
+				3758,
+				3225689,
+			},
+			{
+				"BenchmarkNumberThree-8",
+				1148,
+				1031164,
+			},
+		},
+	}
+
+	r, err := processFile(string(d))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: Test this more thoroughly.
+	if r.pkg != e.pkg {
+		t.Fatalf("processFile() = %v, expected %v", r, e)
+	}
+}

--- a/pkg/cmaps/keys.go
+++ b/pkg/cmaps/keys.go
@@ -1,0 +1,10 @@
+package cmaps
+
+// Returns the keys of the map as a slice in indeterminate order.
+func KeysSlice[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}

--- a/pkg/cmaps/keys_test.go
+++ b/pkg/cmaps/keys_test.go
@@ -1,0 +1,22 @@
+package cmaps
+
+import (
+	"slices"
+	"testing"
+)
+
+// Tests the ability to abtain a slice of keys from a map.
+func TestKeysSlice(t *testing.T) {
+	v := map[string]int{
+		"foo": 1,
+		"bar": 2,
+	}
+
+	e := []string{"bar", "foo"}
+	r := KeysSlice(v)
+	slices.Sort(r) // Sort the slice to ensure deterministic order.
+
+	if len(r) != len(e) || r[0] != e[0] || r[1] != e[1] {
+		t.Errorf("KeysSlice() = %v, expected %v", r, e)
+	}
+}

--- a/pkg/puzzles/1.go
+++ b/pkg/puzzles/1.go
@@ -10,35 +10,13 @@ import (
 // Day 1: Historian Hysteria
 // https://adventofcode.com/2024/day/1
 func dayOne(input string) (int, int) {
-	var left, right []int
+	return d1p1(input), d1p2(input)
+}
 
-	// Parse both lists into separate integer slices.
-	rows := strings.Split(input, "\n")
-	for _, row := range rows {
-		ids := regexp.MustCompile(`\s+`).Split(row, -1)
+// Completes the first half of the puzzle for day 1.
+func d1p1(input string) int {
+	left, right := parseLists(input)
 
-		if len(ids) != 2 {
-			break
-		}
-
-		first, error := strconv.Atoi(ids[0])
-		if error != nil {
-			panic(error)
-		}
-		second, error := strconv.Atoi(ids[1])
-		if error != nil {
-			panic(error)
-		}
-
-		left = append(left, first)
-		right = append(right, second)
-	}
-
-	// Sort both lists in ascending order.
-	slices.Sort(left)
-	slices.Sort(right)
-
-	// Calculate the total distance between the two lists.
 	distance := 0
 	for i := 0; i < len(left); i++ {
 		d := right[i] - left[i]
@@ -48,7 +26,13 @@ func dayOne(input string) (int, int) {
 		distance += d
 	}
 
-	// Calculate the similarity between the two lists.
+	return distance
+}
+
+// Completes the second half of the puzzle for day 1.
+func d1p2(input string) int {
+	left, right := parseLists(input)
+
 	similarity := 0
 	for _, id := range left {
 		position, appears := slices.BinarySearch(right, id)
@@ -65,5 +49,26 @@ func dayOne(input string) (int, int) {
 		}
 	}
 
-	return distance, similarity
+	return similarity
+}
+
+// Parses the two input lists into separate, sorted integer slices.
+func parseLists(input string) ([]int, []int) {
+	rows := strings.Split(input, "\n")
+	left, right := make([]int, len(rows)), make([]int, len(rows))
+
+	for i, row := range rows {
+		ids := regexp.MustCompile(`\s+`).Split(row, -1)
+
+		first, _ := strconv.Atoi(ids[0])
+		second, _ := strconv.Atoi(ids[1])
+
+		left[i] = first
+		right[i] = second
+	}
+
+	slices.Sort(left)
+	slices.Sort(right)
+
+	return left, right
 }

--- a/pkg/puzzles/10_test.go
+++ b/pkg/puzzles/10_test.go
@@ -34,3 +34,33 @@ func TestDayTenPartTwo(t *testing.T) {
 		t.Errorf("d10p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 10.
+func BenchmarkDayTenPartOne(b *testing.B) {
+	input, err := file.ReadInfile(10)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d10p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 10.
+func BenchmarkDayTenPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(10)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d10p2(input)
+	}
+}

--- a/pkg/puzzles/10_test.go
+++ b/pkg/puzzles/10_test.go
@@ -5,69 +5,6 @@ import (
 	"testing"
 )
 
-// Tests the first example of the puzzle for day 10 with one trailhead.
-func TestDayTenPartOneFirstSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "1")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 1
-	if r := d10p1(input); e != r {
-		t.Errorf("d10p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the second example of the puzzle for day 10 with the trail in an
-// upside-down Y shape.
-func TestDayTenPartOneSecondSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "2")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 2
-	if r := d10p1(input); e != r {
-		t.Errorf("d10p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the third example of the puzzle for day 10 with the wider trail moving
-// in many directions relative to the trailhead.
-func TestDayTenPartOneThirdSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "3")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 4
-	if r := d10p1(input); e != r {
-		t.Errorf("d10p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the second example of the puzzle for day 10 with two trails
-// intersecting while moving diagonally.
-func TestDayTenPartOneFourthSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "4")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 3
-	if r := d10p1(input); e != r {
-		t.Errorf("d10p1() = %v, expected %v", r, e)
-	}
-}
-
 // Tests the first part of the puzzle for day 10.
 func TestDayTenPartOne(t *testing.T) {
 	input, err := file.ReadTestFile(10)
@@ -80,53 +17,6 @@ func TestDayTenPartOne(t *testing.T) {
 	e := 36
 	if r := d10p1(input); e != r {
 		t.Errorf("d10p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the fifth example of the puzzle for day 10, demonstrating trail rating.
-func TestDayTenPartTwoFirstSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "5")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 3
-	if r := d10p2(input); e != r {
-		t.Errorf("d10p2() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the sixth example of the puzzle for day 10, demonstrating a single
-// trail head with a few different trails.
-func TestDayTenPartTwoSecondSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "6")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 13
-	if r := d10p2(input); e != r {
-		t.Errorf("d10p2() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the seventh example of the puzzle for day 10, demonstrating a very
-// dense trail, with many different trails coming from a single trail head.
-func TestDayTenPartTwoThirdSample(t *testing.T) {
-	input, err := file.ReadTestFile(10, "7")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 227
-	if r := d10p2(input); e != r {
-		t.Errorf("d10p2() = %v, expected %v", r, e)
 	}
 }
 

--- a/pkg/puzzles/11_test.go
+++ b/pkg/puzzles/11_test.go
@@ -19,3 +19,33 @@ func TestDayElevenPartOne(t *testing.T) {
 		t.Errorf("d11p1() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 11.
+func BenchmarkDayElevenPartOne(b *testing.B) {
+	input, err := file.ReadInfile(11)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d11p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 11.
+func BenchmarkDayElevenPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(11)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d11p2(input)
+	}
+}

--- a/pkg/puzzles/1_test.go
+++ b/pkg/puzzles/1_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// Tests the full solution for day 1 based on the provided example.
-func TestDayOne(t *testing.T) {
+// Tests the first part of the puzzle for day 1.
+func TestDayOnePartOne(t *testing.T) {
 	input, err := file.ReadTestFile(1)
 
 	if err != nil {
@@ -14,10 +14,23 @@ func TestDayOne(t *testing.T) {
 		return
 	}
 
-	eDistance := 11
-	eSimilarity := 31
+	e := 11
+	if r := d1p1(input); e != r {
+		t.Errorf("d1p1() = %v, expected %v", r, e)
+	}
+}
 
-	if rDistance, rSimilarity := dayOne(input); eDistance != rDistance || eSimilarity != rSimilarity {
-		t.Errorf("DayOne() = %v, %v, want %v, %v", rDistance, rSimilarity, eDistance, eSimilarity)
+// Tests the second part of the puzzle for day 1.
+func TestDayOnePartTwo(t *testing.T) {
+	input, err := file.ReadTestFile(1)
+
+	if err != nil {
+		t.Errorf("Could not read test file: %v", err)
+		return
+	}
+
+	e := 31
+	if r := d1p2(input); e != r {
+		t.Errorf("d1p2() = %v, expected %v", r, e)
 	}
 }

--- a/pkg/puzzles/1_test.go
+++ b/pkg/puzzles/1_test.go
@@ -34,3 +34,33 @@ func TestDayOnePartTwo(t *testing.T) {
 		t.Errorf("d1p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 1.
+func BenchmarkDayOnePartOne(b *testing.B) {
+	input, err := file.ReadInfile(1)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d1p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 1.
+func BenchmarkDayOnePartTwo(b *testing.B) {
+	input, err := file.ReadInfile(1)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d1p2(input)
+	}
+}

--- a/pkg/puzzles/2.go
+++ b/pkg/puzzles/2.go
@@ -9,32 +9,42 @@ import (
 // Day 2: Red-Nosed Reports
 // https://adventofcode.com/2024/day/2
 func dayTwo(input string) (int, int) {
-	reports := strings.Split(input, "\n")
+	return d2p1(input), d2p2(input)
+}
+
+// Completes the first half of the puzzle for day 2.
+func d2p1(input string) int {
+	reports := parseReports(input)
+	safe := 0
+
+	for _, report := range reports {
+		// NOTE: Using the dampened result to detect if the answer is safe to avoid
+		// refactoring validateReport into a split function. Maybe I'll fix it one day.
+		_, d := validateReport(report, true)
+		if d {
+			safe++
+		}
+	}
+
+	return safe
+}
+
+// Completes the second half of the puzzle for day 2.
+func d2p2(input string) int {
+	reports := parseReports(input)
 	safe := 0
 	dampened := 0
 
 	for _, report := range reports {
-		// Parse the report into a slice of integers.
-		levels := make([]int, len(strings.Fields(report)))
-		for i, field := range strings.Fields(report) {
-			levels[i], _ = strconv.Atoi(field)
-		}
-
-		// Skip empty reports. TODO: Remove this when input comes in as lines.
-		if len(levels) < 1 {
-			continue
-		}
-
-		// Validate the report.
-		isSafe, isActuallySafe := validateReport(levels, false)
-		if isSafe {
+		s, d := validateReport(report, false)
+		if s {
 			safe++
-		} else if isActuallySafe {
+		} else if d {
 			dampened++
 		}
 	}
 
-	return safe, safe + dampened
+	return safe + dampened
 }
 
 // Validates a single report.
@@ -82,4 +92,20 @@ func validateReport(levels []int, dampened bool) (bool, bool) {
 	}
 
 	return !dampened, dampened
+}
+
+// Parses the input data into a slice of reports, containing a slice of levels.
+func parseReports(input string) [][]int {
+	rows := strings.Split(input, "\n")
+	reports := make([][]int, len(rows))
+
+	for i, row := range rows {
+		levels := make([]int, len(strings.Fields(row)))
+		for j, field := range strings.Fields(row) {
+			levels[j], _ = strconv.Atoi(field)
+		}
+		reports[i] = levels
+	}
+
+	return reports
 }

--- a/pkg/puzzles/2_test.go
+++ b/pkg/puzzles/2_test.go
@@ -34,3 +34,33 @@ func TestDayTwoPartTwo(t *testing.T) {
 		t.Errorf("d2p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 2.
+func BenchmarkDayTwoPartOne(b *testing.B) {
+	input, err := file.ReadInfile(2)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d2p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 2.
+func BenchmarkDayTwoPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(2)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d2p2(input)
+	}
+}

--- a/pkg/puzzles/2_test.go
+++ b/pkg/puzzles/2_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// Tests the full solution for day 2 based on the provided example.
-func TestDayTwo(t *testing.T) {
+// Tests the first part of the puzzle for day 2.
+func TestDayTwoPartOne(t *testing.T) {
 	input, err := file.ReadTestFile(2)
 
 	if err != nil {
@@ -14,10 +14,23 @@ func TestDayTwo(t *testing.T) {
 		return
 	}
 
-	eSafe := 2
-	eActuallySafe := 4
+	e := 2
+	if r := d2p1(input); e != r {
+		t.Errorf("d2p1() = %v, expected %v", r, e)
+	}
+}
 
-	if rSafe, rActuallySafe := dayTwo(input); eSafe != rSafe || eActuallySafe != rActuallySafe {
-		t.Errorf("DayTwo() = %v, %v, want %v, %v", rSafe, rActuallySafe, eSafe, eActuallySafe)
+// Tests the second part of the puzzle for day 2.
+func TestDayTwoPartTwo(t *testing.T) {
+	input, err := file.ReadTestFile(2)
+
+	if err != nil {
+		t.Errorf("Could not read test file: %v", err)
+		return
+	}
+
+	e := 4
+	if r := d2p2(input); e != r {
+		t.Errorf("d2p2() = %v, expected %v", r, e)
 	}
 }

--- a/pkg/puzzles/3_test.go
+++ b/pkg/puzzles/3_test.go
@@ -34,3 +34,33 @@ func TestDayThreePartTwo(t *testing.T) {
 		t.Errorf("d3p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 3.
+func BenchmarkDayThreePartOne(b *testing.B) {
+	input, err := file.ReadInfile(3)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d3p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 3.
+func BenchmarkDayThreePartTwo(b *testing.B) {
+	input, err := file.ReadInfile(3)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d3p2(input)
+	}
+}

--- a/pkg/puzzles/4_test.go
+++ b/pkg/puzzles/4_test.go
@@ -34,3 +34,33 @@ func TestDayFourPartTwo(t *testing.T) {
 		t.Errorf("d4p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 4.
+func BenchmarkDayFourPartOne(b *testing.B) {
+	input, err := file.ReadInfile(4)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d4p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 4.
+func BenchmarkDayFourPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(4)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d4p2(input)
+	}
+}

--- a/pkg/puzzles/5_test.go
+++ b/pkg/puzzles/5_test.go
@@ -34,3 +34,33 @@ func TestDayFivePartTwo(t *testing.T) {
 		t.Errorf("d5p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 5.
+func BenchmarkDayFivePartOne(b *testing.B) {
+	input, err := file.ReadInfile(5)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d5p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 5.
+func BenchmarkDayFivePartTwo(b *testing.B) {
+	input, err := file.ReadInfile(5)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d5p2(input)
+	}
+}

--- a/pkg/puzzles/6_test.go
+++ b/pkg/puzzles/6_test.go
@@ -34,17 +34,3 @@ func TestDaySixPartTwo(t *testing.T) {
 		t.Errorf("d6p2() = %v, expected %v", r, e)
 	}
 }
-
-func TestDaySixEdgeCases(t *testing.T) {
-	input, err := file.ReadTestFile(6, "1")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 0
-	if r := d6p2(input); e != r {
-		t.Errorf("d6p1() = %v, expected %v", r, e)
-	}
-}

--- a/pkg/puzzles/6_test.go
+++ b/pkg/puzzles/6_test.go
@@ -34,3 +34,33 @@ func TestDaySixPartTwo(t *testing.T) {
 		t.Errorf("d6p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 6.
+func BenchmarkDaySixPartOne(b *testing.B) {
+	input, err := file.ReadInfile(6)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d6p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 6.
+func BenchmarkDaySixPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(6)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d6p2(input)
+	}
+}

--- a/pkg/puzzles/7_test.go
+++ b/pkg/puzzles/7_test.go
@@ -34,3 +34,33 @@ func TestDaySevenPartSecond(t *testing.T) {
 		t.Errorf("d7p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 7.
+func BenchmarkDaySevenPartOne(b *testing.B) {
+	input, err := file.ReadInfile(7)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d7p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 7.
+func BenchmarkDaySevenPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(7)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d7p2(input)
+	}
+}

--- a/pkg/puzzles/8_test.go
+++ b/pkg/puzzles/8_test.go
@@ -5,36 +5,6 @@ import (
 	"testing"
 )
 
-// Tests the first example of the puzzle for day 8 where two antennas are present.
-func TestDayEightPartOneFirstSample(t *testing.T) {
-	input, err := file.ReadTestFile(8, "aa")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 2
-	if r := d8p1(input); e != r {
-		t.Errorf("d8p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the second example of the puzzle for day 8 where three antennas are present.
-func TestDayEightPartOneSecondSample(t *testing.T) {
-	input, err := file.ReadTestFile(8, "aaa")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 4
-	if r := d8p1(input); e != r {
-		t.Errorf("d8p1() = %v, expected %v", r, e)
-	}
-}
-
 // Tests the first part of the puzzle for day 8.
 func TestDayEightPartOne(t *testing.T) {
 	input, err := file.ReadTestFile(8)
@@ -47,21 +17,6 @@ func TestDayEightPartOne(t *testing.T) {
 	e := 14
 	if r := d8p1(input); e != r {
 		t.Errorf("d8p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the fourth example of the puzzle for day 8 where T-antennas are present.
-func TestDayEightPartTwoFirstSample(t *testing.T) {
-	input, err := file.ReadTestFile(8, "TTT")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 9
-	if r := d8p2(input); e != r {
-		t.Errorf("d8p2() = %v, expected %v", r, e)
 	}
 }
 

--- a/pkg/puzzles/8_test.go
+++ b/pkg/puzzles/8_test.go
@@ -34,3 +34,33 @@ func TestDayEightPartTwo(t *testing.T) {
 		t.Errorf("d8p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 8.
+func BenchmarkDayEightPartOne(b *testing.B) {
+	input, err := file.ReadInfile(8)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d8p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 8.
+func BenchmarkDayEightPartTwo(b *testing.B) {
+	input, err := file.ReadInfile(8)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d8p2(input)
+	}
+}

--- a/pkg/puzzles/9_test.go
+++ b/pkg/puzzles/9_test.go
@@ -34,3 +34,33 @@ func TestDayNinePartTwo(t *testing.T) {
 		t.Errorf("d9p2() = %v, expected %v", r, e)
 	}
 }
+
+// Benchmarks the first part of the puzzle for day 9.
+func BenchmarkDayNinePartOne(b *testing.B) {
+	input, err := file.ReadInfile(9)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d9p1(input)
+	}
+}
+
+// Benchmarks the second part of the puzzle for day 9.
+func BenchmarkDayNinePartTwo(b *testing.B) {
+	input, err := file.ReadInfile(9)
+
+	if err != nil {
+		b.Errorf("Could not read file: %v", err)
+		return
+	}
+
+	b.ResetTimer()
+	for range b.N {
+		d9p2(input)
+	}
+}

--- a/pkg/puzzles/9_test.go
+++ b/pkg/puzzles/9_test.go
@@ -5,21 +5,6 @@ import (
 	"testing"
 )
 
-// Tests the short example of the puzzle for day 9.
-func TestDayNinePartOneSample(t *testing.T) {
-	input, err := file.ReadTestFile(9, "12345")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 60
-	if r := d9p1(input); e != r {
-		t.Errorf("d9p1() = %v, expected %v", r, e)
-	}
-}
-
 // Tests the first part of the puzzle for day 9.
 func TestDayNinePartOne(t *testing.T) {
 	input, err := file.ReadTestFile(9)
@@ -32,21 +17,6 @@ func TestDayNinePartOne(t *testing.T) {
 	e := 1928
 	if r := d9p1(input); e != r {
 		t.Errorf("d9p1() = %v, expected %v", r, e)
-	}
-}
-
-// Tests the short example of the puzzle for day 9.
-func TestDayNinePartTwoSample(t *testing.T) {
-	input, err := file.ReadTestFile(9, "12345")
-
-	if err != nil {
-		t.Errorf("Could not read test file: %v", err)
-		return
-	}
-
-	e := 132
-	if r := d9p2(input); e != r {
-		t.Errorf("d9p2() = %v, expected %v", r, e)
 	}
 }
 


### PR DESCRIPTION
Adds benchmarking capabilities to all existing puzzle solutions, along with a basic personal best storage in the form of a JSON file to the project.

For now, this is nothing special, and the code is pretty rushed (I wanted to merge this branch to get the actual benchmarks in here quicker), but the actual file storage of the results will come in handy later on as I expand the functionality of this repository.

I have also decided to remove all unit tests of secondary examples from VCS, as they make things annoying when switching between computers, since the input files are not stored in VCS.

As a small extra treat, I added a command line parameter to the main solving command to only run a specific day, so I can postpone performance improvements to past solutions for even longer :)