### PR TITLE
feat: Initialize CLI app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# Advent of Code
+
+A centralized helper and solution provider for Advent of Code puzzles.
+
+## About
+
+During my first run through Advent of Code in 2024, I immediately loved the challenge, and knew I would like to do more years and/or create solutions in multiple programming languages. Building off my solutions, this repository has since reemerged to provide me with the opportunity to pursue that goal, while also offering some extra goodies along the way:
+
+- Randomized puzzle suggestions for use outside the advent
+- Automatic bootstrapping of new puzzles (TODO)
+- Centralized runner for comparing between solutions and languages (TODO)
+
+## CLI
+
+The root of the repository acts as an individual Go module, implementing a CLI tool for interfacing with Advent of Code itself. Specific examples of use cases will be demonstrated in the following sections, but remember - you can always run help, both on the root command, and subcommands to potentially find something more specific to your use case:
+
+```sh
+aoc --help
+```
+
+### Opening puzzles
+
+During the advent, you can open today's puzzle:
+
+```sh
+aoc open
+```
+
+Running the same command outside the advent will open the nearest match to "today" as if it was the advent - the closest advent day's puzzle of the previous year's advent will be opened. But specific puzzles can also be opened, e.g., Day 14 of 2017:
+
+```sh
+aoc open -d 14 -y 2017
+```
+
+Want a challenge? Pick a random puzzle:
+
+```sh
+aoc random
+```
+
+Or, if you want _some_ structure, clamp your randomness to either a specific day, or a specific year, e.g., random puzzle of 2017:
+
+```sh
+aoc random -y 2017
+```
+
+### Bootstrapping puzzles
+
+> [!WARNING]
+> The following is not actually implemented, but I am including this to give an outline of my goals with the repository.
+
+For quicker setup, especially during the advent, you can instantly bootstrap a new puzzle via [`templates`](https://github.com/Lorech/advent-of-code/tree/main/templates):
+
+```sh
+aoc setup --lang go
+```
+
+Templates are scoped to each language, where every file and folder within the directory will be transferred/modified, subject to the new puzzle's requirements. When creating a new template, some special keywords are defined, which you can use to fill out data scoped to the specific puzzle:
+
+- `day` - numeric representation of the day this puzzle represents
+- `year` - numeric representation of the year this puzzle represents
+
+### Solving puzzles
+
+> [!WARNING]
+> The following is not actually implemented, but I am including this to give an outline of my goals with the repository.
+
+Solutions are split by language inside [`solutions`](https://github.com/Lorech/advent-of-code/tree/main/solutions). Each language acts as a fully independent project, subjecting itself to the conventions applied to the specific language. Centralized solver executables are provided by each project, which can then be executed by the CLI:
+
+Get the solution of a puzzle:
+
+```sh
+aoc solve -d 14 -y 17 --lang go
+```
+
+Get the test results of a puzzle:
+
+```sh
+aoc test -d 14 -y 17 --lang go
+```
+
+Get the benchmark results of a puzzle:
+
+```sh
+aoc bench -d 14 -y 17 --lang go
+```
+
+## Input files
+
+The only input data stored within this repository is data created by myself for my own personal test cases. No official Advent of Code input data is provided as per the author's request.
+
+To facilitate the use of multiple languages per puzzle, input data is centralized within the repository, see [`infiles`](https://github.com/Lorech/advent-of-code/tree/main/infiles) for details.
+
+## Contributing
+
+The repository contains my personal solutions, which are by no means the best - many of them may not even be good. Feel free to judge, but contributions to them will not be accepted. As per the main CLI functionality of the repository - feel free to provide suggestions, features, or bug fixes!

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from the CLI!")
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,7 +1,15 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"lorech/advent-of-code/pkg/commands"
+	"os"
+)
 
 func main() {
-	fmt.Println("Hello from the CLI!")
+	cmd := commands.NewRootCommand()
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,9 @@
 module lorech/advent-of-code
 
 go 1.25.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.10.1 // indirect
+	github.com/spf13/pflag v1.0.10 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module lorech/advent-of-code
+
+go 1.25.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
+github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/aoc/date.go
+++ b/pkg/aoc/date.go
@@ -1,0 +1,32 @@
+package aoc
+
+import (
+	"lorech/advent-of-code/pkg/cmath"
+	"time"
+)
+
+const MinDay = 1
+const MaxDay = 25
+const MinYear = 2015
+
+// Gets the maximum year that a puzzle can be picked from.
+//
+// Picks the current year during December; last year otherwise.
+func MaxYear() int {
+	now := time.Now()
+
+	var year int
+	if now.Month() == 12 {
+		year = now.Year()
+	} else {
+		year = now.Year() - 1
+	}
+
+	return year
+}
+
+// Finds the closest puzzle day to current day in a circular fashion.
+func ClosestDay() int {
+	now := time.Now()
+	return cmath.ClosestInRange(now.Day(), 1, 31, MinDay, MaxDay)
+}

--- a/pkg/aoc/url.go
+++ b/pkg/aoc/url.go
@@ -1,0 +1,27 @@
+package aoc
+
+import "fmt"
+
+// Attempts to generate the URL to a puzzle, returning it if successful.
+func PuzzleUrl(year, day int) (string, error) {
+	if year < MinYear || year > MaxYear() {
+		return "", fmt.Errorf("invalid year specified: %d", year)
+	}
+
+	if day < MinDay || day > MaxDay {
+		return "", fmt.Errorf("invalid day specified: %d", day)
+	}
+
+	return fmt.Sprintf("https://adventofcode.com/%d/day/%d", year, day), nil
+}
+
+// Attempts to generate the URL to a puzzle input, returning it if successful.
+func InputUrl(year, day int) (string, error) {
+	url, err := PuzzleUrl(year, day)
+
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%v/input", url), nil
+}

--- a/pkg/aoc/url_test.go
+++ b/pkg/aoc/url_test.go
@@ -1,0 +1,146 @@
+package aoc_test
+
+import (
+	"lorech/advent-of-code/pkg/aoc"
+	"testing"
+)
+
+func TestPuzzleUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		year    int
+		day     int
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "formats correctly",
+			year:    2024,
+			day:     25,
+			want:    "https://adventofcode.com/2024/day/25",
+			wantErr: false,
+		},
+		{
+			name:    "single day has no leading zero",
+			year:    2024,
+			day:     1,
+			want:    "https://adventofcode.com/2024/day/1",
+			wantErr: false,
+		},
+		{
+			name:    "errors when year before aoc start",
+			year:    2010,
+			day:     1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when year that hasn't happened",
+			year:    3000,
+			day:     1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when day invalid",
+			year:    2024,
+			day:     -1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when day after christmas",
+			year:    2024,
+			day:     31,
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := aoc.PuzzleUrl(tt.year, tt.day)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("PuzzleUrl() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("PuzzleUrl() succeeded unexpectedly")
+			}
+			if got == tt.want {
+				t.Errorf("PuzzleUrl() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInputUrl(t *testing.T) {
+	tests := []struct {
+		name    string
+		year    int
+		day     int
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "formats correctly",
+			year:    2024,
+			day:     25,
+			want:    "https://adventofcode.com/2024/day/25/input",
+			wantErr: false,
+		},
+		{
+			name:    "single day has no leading zero",
+			year:    2024,
+			day:     1,
+			want:    "https://adventofcode.com/2024/day/1/input",
+			wantErr: false,
+		},
+		{
+			name:    "errors when year before aoc start",
+			year:    2010,
+			day:     1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when year that hasn't happened",
+			year:    3000,
+			day:     1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when day invalid",
+			year:    2024,
+			day:     -1,
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "errors when day after christmas",
+			year:    2024,
+			day:     31,
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotErr := aoc.InputUrl(tt.year, tt.day)
+			if gotErr != nil {
+				if !tt.wantErr {
+					t.Errorf("InputUrl() failed: %v", gotErr)
+				}
+				return
+			}
+			if tt.wantErr {
+				t.Fatal("InputUrl() succeeded unexpectedly")
+			}
+			if got == tt.want {
+				t.Errorf("InputUrl() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmath/range.go
+++ b/pkg/cmath/range.go
@@ -1,6 +1,14 @@
 package cmath
 
-import "math"
+import (
+	"math"
+	"math/rand/v2"
+)
+
+// Picks a random integer within a range of integers.
+func RandomInRange(min, max int) int {
+	return rand.IntN(max-min) + min
+}
 
 // Finds the closest number in [targetLower, targetUpper] given an input
 // number within [domainLower, domainUpper]. Distances are computed circularly

--- a/pkg/cmath/range.go
+++ b/pkg/cmath/range.go
@@ -1,0 +1,37 @@
+package cmath
+
+import "math"
+
+// Finds the closest number in [targetLower, targetUpper] given an input
+// number within [domainLower, domainUpper]. Distances are computed circularly
+// over the domain range.
+func ClosestInRange(num, domainLower, domainUpper, targetLower, targetUpper int) int {
+	// Normalize inputs to be inside the domain
+	if num < domainLower {
+		num = domainLower
+	}
+	if num > domainUpper {
+		num = domainUpper
+	}
+
+	domainSize := domainUpper - domainLower + 1
+	best := targetLower
+	minDist := math.MaxInt
+
+	for i := targetLower; i <= targetUpper; i++ {
+		// Direct distance
+		dist := int(math.Abs(float64(num - i)))
+
+		// Wrap-around distance
+		wrapDist := domainSize - dist
+
+		// Pick smaller of the two
+		effectiveDist := min(wrapDist, dist)
+		if effectiveDist < minDist {
+			minDist = effectiveDist
+			best = i
+		}
+	}
+
+	return best
+}

--- a/pkg/cmath/range_test.go
+++ b/pkg/cmath/range_test.go
@@ -1,0 +1,80 @@
+package cmath_test
+
+import (
+	"lorech/advent-of-code/pkg/cmath"
+	"testing"
+)
+
+func TestClosestInRange(t *testing.T) {
+	tests := []struct {
+		name                     string
+		num                      int
+		domainLower, domainUpper int
+		targetLower, targetUpper int
+		want                     int
+	}{
+		{
+			name:        "inside range preserved",
+			num:         5,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 5,
+		},
+		{
+			name:        "lower bound preserved",
+			num:         4,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 4,
+		},
+		{
+			name:        "upper bound preserved",
+			num:         7,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 7,
+		},
+		{
+			name:        "clamps onto lower bound",
+			num:         3,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 4,
+		},
+		{
+			name:        "clamps onto upper bound",
+			num:         8,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 7,
+		},
+		{
+			name:        "overflows when in range",
+			num:         10,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 7,
+		},
+		{
+			name:        "underflows when in range",
+			num:         1,
+			domainLower: 1, domainUpper: 10,
+			targetLower: 4, targetUpper: 7,
+			want: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cmath.ClosestInRange(tt.num,
+				tt.domainLower, tt.domainUpper,
+				tt.targetLower, tt.targetUpper)
+
+			if got != tt.want {
+				t.Errorf("ClosestInRange(%v, [%v..%v], [%v..%v]) = %v, want %v",
+					tt.num, tt.domainLower, tt.domainUpper,
+					tt.targetLower, tt.targetUpper, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -14,10 +14,20 @@ func NewOpenCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			year, _ := cmd.Flags().GetInt("year")
 			day, _ := cmd.Flags().GetInt("day")
-			url, err := aoc.PuzzleUrl(year, day)
+			input, _ := cmd.Flags().GetBool("input")
+
+			var url string
+			var err error
+			if input {
+				url, err = aoc.InputUrl(year, day)
+			} else {
+				url, err = aoc.PuzzleUrl(year, day)
+			}
+
 			if err != nil {
 				return err
 			}
+
 			runners.OpenURL(url)
 			return nil
 		},
@@ -25,6 +35,7 @@ func NewOpenCommand() *cobra.Command {
 
 	cmd.Flags().IntP("day", "d", aoc.ClosestDay(), "day to open")
 	cmd.Flags().IntP("year", "y", aoc.MaxYear(), "year to open")
+	cmd.Flags().BoolP("input", "i", false, "open the input")
 
 	return cmd
 }

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"fmt"
 	"lorech/advent-of-code/pkg/aoc"
 	"lorech/advent-of-code/pkg/runners"
 
@@ -12,23 +11,15 @@ func NewOpenCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "open",
 		Short: "Open the puzzle of the day",
-		Args: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			year, _ := cmd.Flags().GetInt("year")
-			if year < aoc.MinYear || year > aoc.MaxYear() {
-				return fmt.Errorf("invalid year specified: %d", year)
-			}
-
 			day, _ := cmd.Flags().GetInt("day")
-			if day < aoc.MinDay || day > aoc.MaxDay {
-				return fmt.Errorf("invalid day specified: %d", day)
+			url, err := aoc.PuzzleUrl(year, day)
+			if err != nil {
+				return err
 			}
-
+			runners.OpenURL(url)
 			return nil
-		},
-		Run: func(cmd *cobra.Command, args []string) {
-			year, _ := cmd.Flags().GetInt("year")
-			day, _ := cmd.Flags().GetInt("day")
-			runners.OpenURL(fmt.Sprintf("https://adventofcode.com/%d/day/%d", year, day))
 		},
 	}
 

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -2,32 +2,24 @@ package commands
 
 import (
 	"fmt"
-	"lorech/advent-of-code/pkg/cmath"
+	"lorech/advent-of-code/pkg/aoc"
 	"lorech/advent-of-code/pkg/runners"
-	"time"
 
 	"github.com/spf13/cobra"
 )
-
-const actualMinDay = 1
-const actualMaxDay = 31
-const minPuzzleDay = 1
-const maxPuzzleDay = 25
-const minPuzzleYear = 2015
 
 func NewOpenCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "open",
 		Short: "Open the puzzle of the day",
 		Args: func(cmd *cobra.Command, args []string) error {
-			_, maxPuzzleYear := defaultPuzzle()
 			year, _ := cmd.Flags().GetInt("year")
-			if year < minPuzzleYear || year > maxPuzzleYear {
+			if year < aoc.MinYear || year > aoc.MaxYear() {
 				return fmt.Errorf("invalid year specified: %d", year)
 			}
 
 			day, _ := cmd.Flags().GetInt("day")
-			if day < minPuzzleDay || day > maxPuzzleDay {
+			if day < aoc.MinDay || day > aoc.MaxDay {
 				return fmt.Errorf("invalid day specified: %d", day)
 			}
 
@@ -40,25 +32,8 @@ func NewOpenCommand() *cobra.Command {
 		},
 	}
 
-	defaultDay, defaultYear := defaultPuzzle()
-	cmd.Flags().IntP("day", "d", defaultDay, "day to open")
-	cmd.Flags().IntP("year", "y", defaultYear, "year to open")
+	cmd.Flags().IntP("day", "d", aoc.ClosestDay(), "day to open")
+	cmd.Flags().IntP("year", "y", aoc.MaxYear(), "year to open")
 
 	return cmd
-}
-
-// Find the default puzzle.
-func defaultPuzzle() (int, int) {
-	now := time.Now()
-
-	day := cmath.ClosestInRange(now.Day(), 1, 31, minPuzzleDay, maxPuzzleDay)
-
-	var year int
-	if now.Month() == 12 {
-		year = now.Year()
-	} else {
-		year = now.Year() - 1
-	}
-
-	return day, year
 }

--- a/pkg/commands/open.go
+++ b/pkg/commands/open.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"fmt"
+	"lorech/advent-of-code/pkg/cmath"
+	"lorech/advent-of-code/pkg/runners"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const actualMinDay = 1
+const actualMaxDay = 31
+const minPuzzleDay = 1
+const maxPuzzleDay = 25
+const minPuzzleYear = 2015
+
+func NewOpenCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "open",
+		Short: "Open the puzzle of the day",
+		Args: func(cmd *cobra.Command, args []string) error {
+			_, maxPuzzleYear := defaultPuzzle()
+			year, _ := cmd.Flags().GetInt("year")
+			if year < minPuzzleYear || year > maxPuzzleYear {
+				return fmt.Errorf("invalid year specified: %d", year)
+			}
+
+			day, _ := cmd.Flags().GetInt("day")
+			if day < minPuzzleDay || day > maxPuzzleDay {
+				return fmt.Errorf("invalid day specified: %d", day)
+			}
+
+			return nil
+		},
+		Run: func(cmd *cobra.Command, args []string) {
+			year, _ := cmd.Flags().GetInt("year")
+			day, _ := cmd.Flags().GetInt("day")
+			runners.OpenURL(fmt.Sprintf("https://adventofcode.com/%d/day/%d", year, day))
+		},
+	}
+
+	defaultDay, defaultYear := defaultPuzzle()
+	cmd.Flags().IntP("day", "d", defaultDay, "day to open")
+	cmd.Flags().IntP("year", "y", defaultYear, "year to open")
+
+	return cmd
+}
+
+// Find the default puzzle.
+func defaultPuzzle() (int, int) {
+	now := time.Now()
+
+	day := cmath.ClosestInRange(now.Day(), 1, 31, minPuzzleDay, maxPuzzleDay)
+
+	var year int
+	if now.Month() == 12 {
+		year = now.Year()
+	} else {
+		year = now.Year() - 1
+	}
+
+	return day, year
+}

--- a/pkg/commands/random.go
+++ b/pkg/commands/random.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"lorech/advent-of-code/pkg/aoc"
 	"lorech/advent-of-code/pkg/cmath"
+	"lorech/advent-of-code/pkg/runners"
 
 	"github.com/spf13/cobra"
 )
@@ -12,9 +13,10 @@ func NewRandomCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "random",
 		Short: "Pick a random puzzle",
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			var randY, randD int
 
+			o, _ := cmd.Flags().GetBool("open")
 			y, _ := cmd.Flags().GetInt("year")
 			d, _ := cmd.Flags().GetInt("day")
 
@@ -30,10 +32,21 @@ func NewRandomCommand() *cobra.Command {
 				randD = d
 			}
 
-			fmt.Printf("Day %d of %d", randD, randY)
+			if o {
+				url, err := aoc.PuzzleUrl(randY, randD)
+				if err != nil {
+					return err
+				}
+				runners.OpenURL(url)
+			} else {
+				fmt.Printf("Day %d of %d", randD, randY)
+			}
+
+			return nil
 		},
 	}
 
+	cmd.Flags().BoolP("open", "o", false, "open the puzzle instead of printing it")
 	cmd.Flags().IntP("day", "d", 0, "lock in the day, picking between a random year's puzzle")
 	cmd.Flags().IntP("year", "y", 0, "lock in the year, picking between it's puzzles")
 	cmd.MarkFlagsMutuallyExclusive("day", "year")

--- a/pkg/commands/random.go
+++ b/pkg/commands/random.go
@@ -1,0 +1,42 @@
+package commands
+
+import (
+	"fmt"
+	"lorech/advent-of-code/pkg/aoc"
+	"lorech/advent-of-code/pkg/cmath"
+
+	"github.com/spf13/cobra"
+)
+
+func NewRandomCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "random",
+		Short: "Pick a random puzzle",
+		Run: func(cmd *cobra.Command, args []string) {
+			var randY, randD int
+
+			y, _ := cmd.Flags().GetInt("year")
+			d, _ := cmd.Flags().GetInt("day")
+
+			if y == 0 {
+				randY = cmath.RandomInRange(aoc.MinYear, aoc.MaxYear())
+			} else {
+				randY = y
+			}
+
+			if d == 0 {
+				randD = cmath.RandomInRange(aoc.MinDay, aoc.MaxDay)
+			} else {
+				randD = d
+			}
+
+			fmt.Printf("Day %d of %d", randD, randY)
+		},
+	}
+
+	cmd.Flags().IntP("day", "d", 0, "lock in the day, picking between a random year's puzzle")
+	cmd.Flags().IntP("year", "y", 0, "lock in the year, picking between it's puzzles")
+	cmd.MarkFlagsMutuallyExclusive("day", "year")
+
+	return cmd
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -10,6 +10,7 @@ func NewRootCommand() *cobra.Command {
 	}
 
 	cmd.AddCommand(NewVersionCommand())
+	cmd.AddCommand(NewOpenCommand())
 
 	return cmd
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -1,0 +1,15 @@
+package commands
+
+import "github.com/spf13/cobra"
+
+func NewRootCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "aoc",
+		Short: "Advent of Code CLI",
+		Long:  "Lightweight utility for quickly setting up for Advent of Code",
+	}
+
+	cmd.AddCommand(NewVersionCommand())
+
+	return cmd
+}

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -11,6 +11,7 @@ func NewRootCommand() *cobra.Command {
 
 	cmd.AddCommand(NewVersionCommand())
 	cmd.AddCommand(NewOpenCommand())
+	cmd.AddCommand(NewRandomCommand())
 
 	return cmd
 }

--- a/pkg/commands/version.go
+++ b/pkg/commands/version.go
@@ -1,0 +1,17 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func NewVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print the running CLI's version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("aoc v0.1.0")
+		},
+	}
+}

--- a/pkg/runners/browser.go
+++ b/pkg/runners/browser.go
@@ -1,0 +1,42 @@
+package runners
+
+import (
+	"os/exec"
+	"runtime"
+)
+
+// Opens the provided URL in the operating system's default browser.
+func OpenURL(url string) error {
+	var cmd, args = buildCommand(url)
+	return exec.Command(cmd, args...).Start()
+}
+
+func buildCommand(url string) (string, []string) {
+	var cmd string
+	var args []string
+
+	switch runtime.GOOS {
+	case "windows": // Windows
+		cmd = "cmd"
+		args = []string{"/c", "start", url}
+	case "darwin": // macOS
+		cmd = "open"
+		args = []string{url}
+	default: // Linux
+		if isWSL() {
+			cmd = "cmd.exe"
+			args = []string{"/c", "start", url}
+		} else {
+			cmd = "xdg-open"
+			args = []string{url}
+		}
+	}
+
+	if len(args) > 1 {
+		// args[0] is used for 'start' command argument
+		// to prevent issues with URLs starting with a quote
+		args = append(args[:1], append([]string{""}, args[1:]...)...)
+	}
+
+	return cmd, args
+}

--- a/pkg/runners/os.go
+++ b/pkg/runners/os.go
@@ -1,0 +1,17 @@
+package runners
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// Check if running through Windows Subsystem for Linux.
+//
+// When running in WSL, command running should be done using Windows APIs.
+func isWSL() bool {
+	releaseData, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(releaseData)), "microsoft")
+}


### PR DESCRIPTION
Initializes the CLI app, providing a base structure to build from, adding new and more useful features for quicker AoC puzzle bootstrapping. This MR bootstraps the CLI app using [Cobra](https://github.com/spf13/cobra), and implements two commands:

- `open`, responsible for opening a specific puzzle in the browser, defaulting to closest date within 1-25, and latest year with a puzzle
- `random`, responsible for picking a random puzzle, optionally clamping the results to either a specific day or a specific year, and, also optionally, opening the puzzle in the browser instead of printing